### PR TITLE
Fix channel unit tests that broke on python 3

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -16,6 +16,8 @@ Next Release
    (nowait) Channel operation. It's an application error to pass a non-None
    completion callback with an asynchronous request, because this callback can
    never be serviced in the asynchronous scenario.
+ - `Channel.basic_reject` fixed to allow `delivery_tag` to be of type `long`
+   as well as `int`. (by quantum5)
 
 0.10.0 2015-09-02
 -----------------

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -416,7 +416,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_basic_reject_spec_with_int_tag(self):
         decoded = spec.Basic.Reject()
-        decoded.decode(''.join(spec.Basic.Reject(1, True).encode()))
+        decoded.decode(b''.join(spec.Basic.Reject(1, True).encode()))
 
         self.assertEqual(decoded.delivery_tag, 1)
         self.assertIs(decoded.requeue, True)
@@ -438,7 +438,7 @@ class ChannelTests(unittest.TestCase):
         # NOTE: we use `sys.maxsize` for compatibility with python 3, which
         # doesn't have `sys.maxint`
         decoded = spec.Basic.Reject()
-        decoded.decode(''.join(spec.Basic.Reject(sys.maxsize, True).encode()))
+        decoded.decode(b''.join(spec.Basic.Reject(sys.maxsize, True).encode()))
 
         self.assertEqual(decoded.delivery_tag, sys.maxsize)
         self.assertIs(decoded.requeue, True)


### PR DESCRIPTION
@quantum5, this passed all platform tests in my test PR #704, so should be ready for merge into your PR #676
